### PR TITLE
fix crash when using verify and mongo driver version bump

### DIFF
--- a/libs/crud.js
+++ b/libs/crud.js
@@ -6,6 +6,7 @@ try {
 }
 
 let read = (model) => async (ctx) => {
+  if(!ctx) return
   let filtered
   let prettify = null
   if (ctx.query != undefined) {
@@ -58,6 +59,7 @@ let read = (model) => async (ctx) => {
 }
 
 let readList = (model) => async (ctx) => {
+  if(!ctx) return
   // console.log('listing...')
   let urlQuery = ctx.query
   let query = {}
@@ -106,6 +108,7 @@ let readList = (model) => async (ctx) => {
 }
 
 let create = (model) => async (ctx) => {
+  if(!ctx) return
   // console.log('creating...')
   let result = await model.create(ctx.data.fields, (err, data) => {
     if (err) {
@@ -131,6 +134,7 @@ let create = (model) => async (ctx) => {
 }
 
 let update = (model) => (ctx) => {
+  if(!ctx) return
   try {
     //will work if adapter is MongoDB
     ObjectID.isValid(ctx.parameters.id)
@@ -171,6 +175,7 @@ let update = (model) => (ctx) => {
 }
 
 let destroy = (model) => (ctx) => {
+  if(!ctx) return
   // console.log('detroying...')
   try {
     //will work if adapter is MongoDB

--- a/libs/privatecrud.js
+++ b/libs/privatecrud.js
@@ -6,6 +6,7 @@ try {
 }
 
 let privateRead = (model) => (ctx) => {
+  if(!ctx) return
   ctx.res.onAborted(() => {
     console.log('read request Aborted')
     return false
@@ -62,6 +63,7 @@ let privateRead = (model) => (ctx) => {
 }
 
 let privateReadList = (model) => async (ctx) => {
+  if(!ctx) return
   ctx.res.onAborted(() => {
     console.log('readlist request Aborted')
     return false
@@ -118,6 +120,7 @@ let privateReadList = (model) => async (ctx) => {
 }
 
 let privateCreate = (model) => async (ctx) => {
+  if(!ctx) return
   ctx.res.onAborted(() => {
     console.log('create request Aborted')
     return false
@@ -148,6 +151,7 @@ let privateCreate = (model) => async (ctx) => {
 }
 
 let privateUpdate = (model) => async (ctx) => {
+  if(!ctx) return
   try {
     const { res } = ctx
     ctx.res.onAborted(() => {
@@ -210,6 +214,7 @@ let privateUpdate = (model) => async (ctx) => {
 }
 
 let privateDestroy = (model) => (ctx) => {
+  if(!ctx) return
   ctx.res.onAborted(() => {
     console.log('destroy request Aborted')
     return false
@@ -239,6 +244,7 @@ let privateDestroy = (model) => (ctx) => {
 }
 
 let privateCount = (model) => (ctx) => {
+  if(!ctx) return
   model.count({ where: { ownerid: ctx.UserPayload.user.id } }, (err, c) => {
     ctx.res.end(
       JSON.stringify({

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "mocha": "^7.1.1",
-    "mongodb": "^3.1.13",
+    "mongodb": "^3.7.1",
     "tingodb": "^0.6.1"
   }
 }


### PR DESCRIPTION
It's my first pull request, I will try to make this correctly
As referenced in Issue https://github.com/jmdisuanco/pinipig/issues/14 the old mongo driver have a bug that will cause circular dependency errors, it's possible to go to the latest 3.x version.
Another issue about pinipig itself, is when using the auth.verify function because in case of error it will close the response and the chained functions about crud operations will fail
To reproduce it just try any route like this `GET: [cors, verify, rl]` and send a request without the jwt token, 
`
block = () => {
    ctx.res.end('{"result":"Unauthorized}"')
    return
  }
` 
this will send back a null ctx and the next crud operation will make the server crash.
For now I didn't update the version number, if everything is fine it needs to be updated before merging